### PR TITLE
Add `nosearch` parameter

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,7 +3,7 @@ import Search from "../components/Search/Search";
 import { Link, useLocation, useSearchParams } from "react-router-dom";
 import NDK, { NDKUserProfile } from "@nostrband/ndk";
 import { nip19 } from "nostr-tools";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import MarkdownComponent from "../components/MarkdownComponent/MarkdownComponent";
 import { Spinner } from "react-bootstrap";
 
@@ -13,6 +13,7 @@ const Home = ({ ndk }: { ndk: NDK }) => {
   const [id, setId] = useState<string>(
     searchParams.get("id")! ? searchParams.get("id")! : ""
   );
+  const hasNoSearch = useRef<boolean>(searchParams.has("nosearch"));
   const [author, setAuthor] = useState<NDKUserProfile | null>();
   const [authorNpub, setAuthorNpub] = useState("");
   const [eventContent, setEventContent] = useState("");
@@ -161,7 +162,7 @@ const Home = ({ ndk }: { ndk: NDK }) => {
       )}
       {id && (
         <>
-          <Search />
+          {!hasNoSearch.current && <Search />}
           {isLoading && (
             <div className="d-flex justify-content-center pt-3">
               <Spinner />


### PR DESCRIPTION
I don't think the search box is always necessary, so I added a new parameter `nosearch` as a query string that hides the search box. The URL will look like: `https://replies-mu.vercel.app/?id=<nip19>&nosearch`.

![screenshot](https://github.com/nostrband/replies/assets/18229040/166fa810-89dd-4d51-bf63-ae867e45c374)
